### PR TITLE
Add greet endpoint in Phoenix skeleton

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,3 @@
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,0 +1,9 @@
+import Config
+
+config :elixir_phoenix_api, ElixirPhoenixApiWeb.Endpoint,
+  url: [host: "localhost"],
+  secret_key_base: String.duplicate("a", 64),
+  render_errors: [accepts: ["json"]],
+  pubsub_server: ElixirPhoenixApi.PubSub
+
+config :logger, level: :info

--- a/lib/elixir_phoenix_api/application.ex
+++ b/lib/elixir_phoenix_api/application.ex
@@ -1,0 +1,22 @@
+defmodule ElixirPhoenixApi.Application do
+  @moduledoc false
+
+  use Application
+
+  @impl true
+  def start(_type, _args) do
+    children = [
+      {Phoenix.PubSub, name: ElixirPhoenixApi.PubSub},
+      ElixirPhoenixApiWeb.Endpoint
+    ]
+
+    opts = [strategy: :one_for_one, name: ElixirPhoenixApi.Supervisor]
+    Supervisor.start_link(children, opts)
+  end
+
+  @impl true
+  def config_change(changed, _new, removed) do
+    ElixirPhoenixApiWeb.Endpoint.config_change(changed, removed)
+    :ok
+  end
+end

--- a/lib/elixir_phoenix_api_web.ex
+++ b/lib/elixir_phoenix_api_web.ex
@@ -1,0 +1,21 @@
+defmodule ElixirPhoenixApiWeb do
+  @moduledoc false
+
+  def controller do
+    quote do
+      use Phoenix.Controller, namespace: ElixirPhoenixApiWeb
+
+      import Plug.Conn
+    end
+  end
+
+  def router do
+    quote do
+      use Phoenix.Router
+    end
+  end
+
+  defmacro __using__(which) when is_atom(which) do
+    apply(__MODULE__, which, [])
+  end
+end

--- a/lib/elixir_phoenix_api_web/controllers/greet_controller.ex
+++ b/lib/elixir_phoenix_api_web/controllers/greet_controller.ex
@@ -1,0 +1,7 @@
+defmodule ElixirPhoenixApiWeb.GreetController do
+  use ElixirPhoenixApiWeb, :controller
+
+  def index(conn, _params) do
+    json(conn, %{message: "Hello World"})
+  end
+end

--- a/lib/elixir_phoenix_api_web/endpoint.ex
+++ b/lib/elixir_phoenix_api_web/endpoint.ex
@@ -1,0 +1,8 @@
+defmodule ElixirPhoenixApiWeb.Endpoint do
+  use Phoenix.Endpoint, otp_app: :elixir_phoenix_api
+
+  plug(Plug.RequestId)
+  plug(Plug.Telemetry, event_prefix: [:phoenix, :endpoint])
+
+  plug(ElixirPhoenixApiWeb.Router)
+end

--- a/lib/elixir_phoenix_api_web/router.ex
+++ b/lib/elixir_phoenix_api_web/router.ex
@@ -1,0 +1,13 @@
+defmodule ElixirPhoenixApiWeb.Router do
+  use ElixirPhoenixApiWeb, :router
+
+  pipeline :api do
+    plug(:accepts, ["json"])
+  end
+
+  scope "/", ElixirPhoenixApiWeb do
+    pipe_through(:api)
+
+    get("/greet", GreetController, :index)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -1,0 +1,30 @@
+defmodule ElixirPhoenixApi.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :elixir_phoenix_api,
+      version: "0.1.0",
+      elixir: "~> 1.14",
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
+  end
+
+  def application do
+    [
+      mod: {ElixirPhoenixApi.Application, []},
+      extra_applications: [:logger]
+    ]
+  end
+
+  defp deps do
+    [
+      {:phoenix, "~> 1.7"},
+      {:phoenix_pubsub, "~> 2.1"},
+      {:telemetry_metrics, "~> 0.6"},
+      {:telemetry_poller, "~> 1.0"},
+      {:plug_cowboy, "~> 2.5"}
+    ]
+  end
+end

--- a/test/elixir_phoenix_api_web/controllers/greet_controller_test.exs
+++ b/test/elixir_phoenix_api_web/controllers/greet_controller_test.exs
@@ -1,0 +1,16 @@
+defmodule ElixirPhoenixApiWeb.GreetControllerTest do
+  use ExUnit.Case, async: true
+  use Plug.Test
+
+  alias ElixirPhoenixApiWeb.Router
+
+  @opts Router.init([])
+
+  test "GET /greet" do
+    conn = conn(:get, "/greet")
+    conn = Router.call(conn, @opts)
+
+    assert conn.status == 200
+    assert conn.resp_body == ~s({"message":"Hello World"})
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()


### PR DESCRIPTION
## Summary
- scaffold minimal Phoenix application structure
- add `/greet` route returning a JSON hello message
- include basic test for the greet endpoint

## Testing
- `mix test` *(fails: Mix requires the Hex package manager to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_689f6bde7bf0832e8ed6327b1504ec93